### PR TITLE
Set thread names for renderThread and tickThread

### DIFF
--- a/src/main/java/nengen/Nengen.java
+++ b/src/main/java/nengen/Nengen.java
@@ -49,7 +49,9 @@ public class Nengen {
 		GameContextWrapper wrapper = new GameContextWrapper(context, glContext);
 
 		Thread renderThread = new Thread(new GameWindowUpdater(config, wrapper, glContext));
+		renderThread.setName("Render Thread");
 		Thread tickThread = new Thread(new GameTickUpdater(config, wrapper));
+		tickThread.setName("Tick Thread");
 		tickThread.start();
 		renderThread.start();
 	}


### PR DESCRIPTION
Makes better error messages:
![image](https://github.com/user-attachments/assets/de8afabb-3198-4b63-995d-2f56ffdb844c)

(Used to say `Exception in thread "Thread-1" ...`)