### PR TITLE
Fix JUnit imports in NengenConfigurationTest

### DIFF
--- a/src/test/java/nengen/NengenConfigurationTest.java
+++ b/src/test/java/nengen/NengenConfigurationTest.java
@@ -1,7 +1,7 @@
 package nengen;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class NengenConfigurationTest {
 


### PR DESCRIPTION
Fixes #8

Update `NengenConfigurationTest.java` to use JUnit 5 imports.

* Change import `org.junit.Test` to `org.junit.jupiter.api.Test`.
* Change import `org.junit.Assert` to `org.junit.jupiter.api.Assertions`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/virtual-cardboard/nengen/issues/8?shareId=6c4d3927-2413-4d30-8413-c47aa7e58f70).