### PR TITLE
Add Maven assembly step to GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Build with Maven
         run: mvn clean install
 
+      - name: Run Maven Assembly
+        run: mvn clean compile assembly:single
+
+      - name: Copy JAR to top level
+        run: cp target/*.jar .
+
       - name: Publish to GitHub Packages
         run: mvn deploy
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.class
 *.log
-*.jar
 *.war
 *.ear
 *.zip


### PR DESCRIPTION
Add steps to GitHub Actions workflow to run Maven Assembly and copy JAR file to top level

* Add a new step in `.github/workflows/publish.yml` to run `mvn clean compile assembly:single` after the build step
* Add a new step in `.github/workflows/publish.yml` to copy the generated JAR file from the `target/` folder to the top level of the repository
* Remove the line that excludes `*.jar` files in `.gitignore`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/virtual-cardboard/nengen/pull/26?shareId=fc9a2633-b53a-49de-90eb-d765a601240e).