### PR TITLE
Add sources to the Maven project using the maven-source-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,19 @@
                     </descriptorRefs>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Add the `maven-source-plugin` to the Maven project to generate source JARs.

* Add the `maven-source-plugin` to the `<build>` section in `pom.xml`.
* Configure the `maven-source-plugin` to attach the source JARs to the build process.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/virtual-cardboard/nengen/pull/30?shareId=0edc651e-4bbf-41a8-99fc-6502501ab2bb).