### PR TITLE
Add GitHub Actions workflow to automatically create a new release on main branch commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Create Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Build with Maven
+        run: mvn clean install
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.sha }}
+          release_name: Release ${{ github.sha }}
+          draft: false
+          prerelease: false

--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ The 4th iteration of virtual cardboard's Java game engine. This LWJGL-based engi
 ## Automatic Deployment to GitHub Packages
 
 This project is configured to automatically deploy to GitHub Packages using GitHub Actions on each commit to the `main` branch. No manual deployment steps are required.
+
+## Automatic Release Creation
+
+This project is configured to automatically create a new release using GitHub Actions on each commit to the `main` branch. No manual release steps are required.


### PR DESCRIPTION
Add a new GitHub Actions workflow to automatically create a new release when the `main` branch is committed.

* **.github/workflows/release.yml**
  - Create a new GitHub Actions workflow file to automatically create a new release when the `main` branch is committed.
  - Add steps to checkout the repository, set up JDK, build with Maven, and create a new release using `actions/create-release@v1`.

* **README.md**
  - Update the `README.md` to mention the automatic creation of a new release on each commit to the `main` branch.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/virtual-cardboard/nengen/pull/36?shareId=1005805f-9ad0-4901-8467-01c45a220262).